### PR TITLE
Fix/handle missing dataset

### DIFF
--- a/src/dataset/download.py
+++ b/src/dataset/download.py
@@ -21,7 +21,7 @@ presentation_data_schema = {
     'lon': 'float',
     'species': 'str',
     'author_email': 'str',
-    'date' : 'timestamp',
+    'date' : 'datetime64[ns]',
 }
 
 def try_download_dataset(dataset_id:str, data_files:str) -> dict:
@@ -84,4 +84,5 @@ def get_dataset() -> pd.DataFrame:
             'author_email': metadata["train"]["author_email"],
             'date': metadata["train"]["date"],}
         )
+        
     return df

--- a/src/dataset/download.py
+++ b/src/dataset/download.py
@@ -52,7 +52,7 @@ def try_download_dataset(dataset_id:str, data_files:str) -> dict:
         # dataset file not found, caused by a lack of parquet file in the dataset
         # (not the error raised when network problems)
         t2 = time.time(); elap = t2 - t1
-        msg = f"Error downloading dataset (missing parquet file for dataset '{dataset_id}: {e}.  (after {elap:.2f}s)."
+        msg = f"Error downloading dataset (missing parquet file for dataset '{dataset_id}': {e}.  (after {elap:.2f}s)."
         with st.expander(
                 f"Error: missing parquet file for dataset '{dataset_id}'. Click for more details...", 
                 expanded=False):

--- a/src/dataset/download.py
+++ b/src/dataset/download.py
@@ -48,11 +48,26 @@ def try_download_dataset(dataset_id:str, data_files:str) -> dict:
         st.error(msg)
         m_logger.error(msg)
         metadata = {}
+    except FileNotFoundError as e:
+        # dataset file not found, caused by a lack of parquet file in the dataset
+        # (not the error raised when network problems)
+        t2 = time.time(); elap = t2 - t1
+        msg = f"Error downloading dataset (missing parquet file for dataset '{dataset_id}: {e}.  (after {elap:.2f}s)."
+        with st.expander(
+                f"Error: missing parquet file for dataset '{dataset_id}'. Click for more details...", 
+                expanded=False):
+            st.error(msg)
+
+        m_logger.error(msg)
+        metadata = {}
+        
     except Exception as e:
         # catch all (other) exceptions and log them, handle them once isolated 
         t2 = time.time(); elap = t2 - t1
         msg = f"!!Unknown Error!! downloading dataset: {e}.  (after {elap:.2f}s)."
-        st.error(msg)
+        with st.expander("Error details", expanded=False):
+            st.error(msg)
+        #st.error(msg)
         m_logger.error(msg)
         metadata = {}
         
@@ -62,6 +77,8 @@ def try_download_dataset(dataset_id:str, data_files:str) -> dict:
     #st.write(msg)
     return metadata
 
+
+# TODO: add tests, esp edge cases where dataset is not available
 def get_dataset() -> pd.DataFrame:
     """
     Downloads the dataset from Hugging Face and prepares it for use.
@@ -84,5 +101,5 @@ def get_dataset() -> pd.DataFrame:
             'author_email': metadata["train"]["author_email"],
             'date': metadata["train"]["date"],}
         )
-        
+
     return df

--- a/src/pages/3_🤝_data requests.py
+++ b/src/pages/3_🤝_data requests.py
@@ -55,6 +55,7 @@ lat_min, lat_max = float(df['lat'].min()), float(df['lat'].max())
 lon_min, lon_max = float(df['lon'].min()), float(df['lon'].max())
 date_min, date_max = df['date'].min(), df['date'].max()
 
+# NaN or NaT aren't accepted by slider widgets
 if np.isnan(lat_min) or np.isnan(lat_max):
     st.warning("Latitude range includes NaN, not attempting to present filtering options")
     give_up_insufficient_data = True
@@ -62,9 +63,22 @@ if np.isnan(lat_min) or np.isnan(lat_max):
 if np.isnan(lon_min) or np.isnan(lon_max):
     st.warning("Longitude range includes NaN, not attempting to present filtering options")
     give_up_insufficient_data = True
-    
+
 if date_min is pd.NaT or date_max is pd.NaT:
     st.warning("One or both dates are undefined (NaT), not attempting to present filtering options")
+    give_up_insufficient_data = True
+
+# zero range is also not accepted by the slider widgets
+if lat_min == lat_max:
+    st.warning("Latitude range has no variability (min equals max), not attempting to present filtering options")
+    give_up_insufficient_data = True
+
+if lon_min == lon_max:
+    st.warning("Longitude range has no variability (min equals max), not attempting to present filtering options")
+    give_up_insufficient_data = True
+
+if date_min == date_max:
+    st.warning("Date range has no variability (min equals max), not attempting to present filtering options")
     give_up_insufficient_data = True
 
 if give_up_insufficient_data:

--- a/src/pages/3_🤝_data requests.py
+++ b/src/pages/3_🤝_data requests.py
@@ -55,11 +55,11 @@ lat_min, lat_max = float(df['lat'].min()), float(df['lat'].max())
 lon_min, lon_max = float(df['lon'].min()), float(df['lon'].max())
 date_min, date_max = df['date'].min(), df['date'].max()
 
-if lat_min is np.nan or lat_max is np.nan:
+if np.isnan(lat_min) or np.isnan(lat_max):
     st.warning("Latitude range includes NaN, not attempting to present filtering options")
     give_up_insufficient_data = True
 
-if lon_min is np.nan or lon_max is np.nan:
+if np.isnan(lon_min) or np.isnan(lon_max):
     st.warning("Longitude range includes NaN, not attempting to present filtering options")
     give_up_insufficient_data = True
     

--- a/src/pages/3_🤝_data requests.py
+++ b/src/pages/3_🤝_data requests.py
@@ -1,4 +1,6 @@
 import streamlit as st
+import pandas as pd
+import numpy as np
 
 st.set_page_config(
     page_title="Requests",
@@ -33,39 +35,69 @@ if st.button("REQUEST DATA",
              icon="🐚"):
     selected = [k for k, v in st.session_state.checkbox_states.items() if v]
     if selected:
-        st.success(f"Request submitted for: the specie {', '.join(selected)}")
+        st.success(f"Request submitted for: the species {', '.join(selected)}")
     else:
         st.warning("No selections made.")
 
-# Latitude range filter
+# validate that we have sufficient data to filter
+# NOTE: this strategy does not implement partial filtering, so if any of the 
+#       dimensions is unsuitable, we give up. However, we report all problems
+#       first, and then stop the page
+give_up_insufficient_data = False
+
+# basic protection: if df is empty, don't/can't proceed
+if df.empty or len(df) == 0: 
+    st.warning("Fetched dataset is empty, not attempting to present filtering options")
+    give_up_insufficient_data = True
+
+# check data is valid for all sliders, else give up
 lat_min, lat_max = float(df['lat'].min()), float(df['lat'].max())
+lon_min, lon_max = float(df['lon'].min()), float(df['lon'].max())
+date_min, date_max = df['date'].min(), df['date'].max()
+
+if lat_min is np.nan or lat_max is np.nan:
+    st.warning("Latitude range includes NaN, not attempting to present filtering options")
+    give_up_insufficient_data = True
+
+if lon_min is np.nan or lon_max is np.nan:
+    st.warning("Longitude range includes NaN, not attempting to present filtering options")
+    give_up_insufficient_data = True
+    
+if date_min is pd.NaT or date_max is pd.NaT:
+    st.warning("One or both dates are undefined (NaT), not attempting to present filtering options")
+    give_up_insufficient_data = True
+
+if give_up_insufficient_data:
+    st.stop()    
+
+# Latitude range filter
 lat_range = st.sidebar.slider(
     "Latitude range",
-    min_value=float(df['lat'].min()),
-    max_value=float(df['lat'].max()),
-    value=st.session_state.get("lat_range", (df['lat'].min(), df['lat'].max()))
+    min_value=lat_min,
+    max_value=lat_max,
+    value=st.session_state.get("lat_range", (lat_min, lat_max))
 )
 st.session_state.lat_range = lat_range
 
 # Longitude range filter
-lon_min, lon_max = float(df['lon'].min()), float(df['lon'].max())
 lon_range = st.sidebar.slider(
     "Longitude range",
-    min_value=float(df['lon'].min()),
-    max_value=float(df['lon'].max()),
-    value=st.session_state.get("lon_range", (df['lon'].min(), df['lon'].max()))
+    min_value=lon_min,
+    max_value=lon_max,
+    value=st.session_state.get("lon_range", (lon_min, lon_max))
 )
 st.session_state.lon_range = lon_range
+
 # Date range filter
 date_range = st.sidebar.date_input(
     "Date range",
-    value=st.session_state.get("date_range", (df['date'].min(), df['date'].max())),
-    min_value=df['date'].min(),
-    max_value=df['date'].max()
+    value=st.session_state.get("date_range", (date_min, date_max)),
+    min_value=date_min,
+    max_value=date_max
 )
 st.session_state.date_range = date_range
 
-# Show authors per specie
+# Show authors per species
 show_new_data_view(df)
 
 


### PR DESCRIPTION
Bug fixes to resolve #46 

- the strategy for handling missing data in the data_requests page might be too aggressive, i.e. giving up if any dimension is not filterable. However, it is likely to arise only if we haven't got any data at all, or all rows are corrupted and so removed in the cleanup step.

- manually tested with the empty main_dataset -> map presents ok, data_requests page shows user the problems and then stops without crashing
- manually tested with the non-empty temp_dataset -> map presents ok, data_requests page is functional as before.
- manually tested with a dataset including a single point -> map shows the one point, data_requests page shows user the problems and then stops without crashing (1 point has zero range so the sliders can't be created)

